### PR TITLE
feat: display error on screen

### DIFF
--- a/Random_quotes/then-catch.js
+++ b/Random_quotes/then-catch.js
@@ -11,8 +11,8 @@ function generateQuote() {
         quote = '"' + quote + '"';
         document.getElementById('text').textContent = quote;
       })
-      .catch(error => {
-        console.error('Error in generating Quote');
+      .catch(() => {
+        document.getElementById('text').textContent = 'Error occurred while generating the quote.';
       });
   }
   


### PR DESCRIPTION
# Description

This pr fixes #3
Earlier the code used to print the error on the console. Now, it has been changed and the error is displayed on the screen.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality

## How Has This Been Tested?
To test the error, I disconnected the device from the internet and the error is shown as expected.

- [x] Test A

![Screenshot (163)](https://github.com/Ritwikgotbugs/Quote-Fact-Generator/assets/101137482/a7228957-3fb8-4ef5-aacc-f2e94417c404)

## Changes
`console.error('Error in generating Quote');`
to
`.catch(() => {
        document.getElementById('text').textContent = 'Error occurred while generating the quote.';
      });`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules