### PR TITLE
fix: prevent multiple api calls on button spam

### DIFF
--- a/Random_quotes/await.js
+++ b/Random_quotes/await.js
@@ -1,13 +1,29 @@
-const limit = 1; // Define the limit
+const limit = 1; 
+let request = false;
 
 async function getFacts(limit) {
-    const response = await fetch(`https://api.api-ninjas.com/v1/facts?limit=${limit}`, {
-        headers: { 'X-Api-Key': '0lAora48t99zuI7tWeiAoA==61EUmZBNtWI4oyN8' },
-    });
 
-    const result = await response.json();
+    if (request) {
+        return;
+    }
 
-    return result;
+    request = true;
+
+    try {
+        const response = await fetch(`https://api.api-ninjas.com/v1/facts?limit=${limit}`, {
+          headers: { 'X-Api-Key': '0lAora48t99zuI7tWeiAoA==61EUmZBNtWI4oyN8' },
+        });
+    
+        const result = await response.json();
+    
+        return result;
+
+      } catch {
+        throw document.getElementById('text').textContent = 'Error occurred while generating the fact';
+
+      } finally {
+        request = false;
+      }
 }
 
 const button = document.querySelector('#fact');

--- a/Random_quotes/then-catch.js
+++ b/Random_quotes/then-catch.js
@@ -1,4 +1,12 @@
+let requestInProgress = false;
+
 function generateQuote() {
+  if (requestInProgress) {
+    return;
+  }
+
+  requestInProgress = true;
+
     fetch(`https://api.api-ninjas.com/v1/quotes?category=computers`, {
       headers: {
         'X-Api-Key': '0lAora48t99zuI7tWeiAoA==61EUmZBNtWI4oyN8',
@@ -13,6 +21,9 @@ function generateQuote() {
       })
       .catch(() => {
         document.getElementById('text').textContent = 'Error occurred while generating the quote.';
+      })
+      .finally(() => {
+        requestInProgress = false;
       });
   }
   


### PR DESCRIPTION
# Description

This pr prevents calling the API multiple times on spamming the buttons which used to automatically change the text nth times the button was pressed. 
This applies to both of the buttons having different ways of calling the API. I have included a new bool "request" which on true enables the button to call the API once and when the response has been fetched, it gets switched back to false.

This pr fixes #4 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Test A
This test has been done using manual spamming of the button. On multiple requests, the API is fetched only once which was the desired outcome,
- [x] Test B
This Test has been done using the **network** feature present in the inspect element tab on chrome. On multiple requests, only one request gets processed and fetches the text.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
